### PR TITLE
[docs] Visualization of the SRAgent's codebase

### DIFF
--- a/.codeboarding/Agent_Workflow_Orchestrator.md
+++ b/.codeboarding/Agent_Workflow_Orchestrator.md
@@ -1,0 +1,217 @@
+```mermaid
+
+graph LR
+
+    Agent_Workflow_Orchestrator["Agent Workflow Orchestrator"]
+
+    Find_Datasets_Workflow["Find Datasets Workflow"]
+
+    SRX_Info_Workflow["SRX Info Workflow"]
+
+    Metadata_Workflow["Metadata Workflow"]
+
+    Tissue_Ontology_Workflow["Tissue Ontology Workflow"]
+
+    Convert_Workflow["Convert Workflow"]
+
+    Workflow_Utilities["Workflow Utilities"]
+
+    Database_Layer["Database Layer"]
+
+    Organisms_Module["Organisms Module"]
+
+    CLI_Components["CLI Components"]
+
+    Agent_Workflow_Orchestrator -- "orchestrates" --> Find_Datasets_Workflow
+
+    Agent_Workflow_Orchestrator -- "orchestrates" --> SRX_Info_Workflow
+
+    Agent_Workflow_Orchestrator -- "orchestrates" --> Metadata_Workflow
+
+    Agent_Workflow_Orchestrator -- "orchestrates" --> Tissue_Ontology_Workflow
+
+    Agent_Workflow_Orchestrator -- "orchestrates" --> Convert_Workflow
+
+    Agent_Workflow_Orchestrator -- "utilizes" --> Workflow_Utilities
+
+    Find_Datasets_Workflow -- "initiates" --> SRX_Info_Workflow
+
+    Find_Datasets_Workflow -- "depends on" --> SRX_Info_Workflow
+
+    Find_Datasets_Workflow -- "leverages" --> Workflow_Utilities
+
+    Find_Datasets_Workflow -- "interacts with" --> Database_Layer
+
+    SRX_Info_Workflow -- "relies on" --> Convert_Workflow
+
+    SRX_Info_Workflow -- "relies on" --> Metadata_Workflow
+
+    SRX_Info_Workflow -- "leverages" --> Workflow_Utilities
+
+    SRX_Info_Workflow -- "interacts with" --> Database_Layer
+
+    Metadata_Workflow -- "utilizes" --> Tissue_Ontology_Workflow
+
+    Metadata_Workflow -- "leverages" --> Workflow_Utilities
+
+    Metadata_Workflow -- "interacts with" --> Database_Layer
+
+    Metadata_Workflow -- "uses" --> Organisms_Module
+
+    Tissue_Ontology_Workflow -- "leverages" --> Workflow_Utilities
+
+    Convert_Workflow -- "leverages" --> Workflow_Utilities
+
+    CLI_Components -- "calls" --> Find_Datasets_Workflow
+
+    CLI_Components -- "calls" --> SRX_Info_Workflow
+
+    CLI_Components -- "calls" --> Metadata_Workflow
+
+    CLI_Components -- "calls" --> Convert_Workflow
+
+    CLI_Components -- "calls" --> Tissue_Ontology_Workflow
+
+    click Agent_Workflow_Orchestrator href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//Agent_Workflow_Orchestrator.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The Agent Workflow Orchestrator is a pivotal component within the SRAgent system, designed to manage and sequence complex, multi-step bioinformatics data curation and retrieval processes. It acts as the central coordination point, defining the execution order of various sub-workflows and managing their interactions to accomplish high-level tasks. This orchestration ensures a structured, automated, and efficient approach to handling diverse bioinformatics data.
+
+
+
+### Agent Workflow Orchestrator [[Expand]](./Agent_Workflow_Orchestrator.md)
+
+The overarching component responsible for defining, coordinating, and executing complex, multi-step data curation and retrieval processes. It ensures the structured flow and interaction of various sub-workflows to achieve high-level bioinformatics tasks.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Find Datasets Workflow
+
+Manages the process of identifying and retrieving relevant bioinformatics datasets based on specified criteria.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### SRX Info Workflow
+
+Focuses on gathering and processing detailed information related to SRX (SRA Experiment) accessions, often involving external data sources.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Metadata Workflow
+
+Handles the extraction, processing, and curation of metadata associated with various bioinformatics data entities, ensuring data quality and consistency.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Tissue Ontology Workflow
+
+Integrates and processes tissue-specific ontological information, crucial for standardizing and enriching biological sample annotations.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Convert Workflow
+
+Responsible for managing data format conversions between different bioinformatics standards or internal representations.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Workflow Utilities
+
+Provides a collection of common utility functions and helper methods that are leveraged across multiple workflow components, promoting code reusability and maintainability.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Database Layer
+
+Manages all interactions with the underlying database, handling data persistence, retrieval, and updates for the entire SRAgent system.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Organisms Module
+
+Provides functionalities related to organism-specific data handling, validation, or lookup, ensuring biological accuracy in data processing.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### CLI Components
+
+Provides the command-line interface for user interaction, serving as the entry point for initiating various workflows and system operations.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Core_AI_Agents.md
+++ b/.codeboarding/Core_AI_Agents.md
@@ -1,0 +1,279 @@
+```mermaid
+
+graph LR
+
+    SRAgent_Orchestrator["SRAgent Orchestrator"]
+
+    NCBI_Entrez_Agent["NCBI Entrez Agent"]
+
+    Dataset_Discovery_Agent["Dataset Discovery Agent"]
+
+    Tissue_Ontology_Agent["Tissue Ontology Agent"]
+
+    BigQuery_Integration_Agent["BigQuery Integration Agent"]
+
+    Sequence_Analysis_Agent["Sequence Analysis Agent"]
+
+    Agent_Output_Formatter["Agent Output Formatter"]
+
+    Agent_Utilities["Agent Utilities"]
+
+    Workflow_Orchestrator["Workflow Orchestrator"]
+
+    External_Service_Integration["External Service Integration"]
+
+    Workflow_Orchestrator -- "uses" --> SRAgent_Orchestrator
+
+    SRAgent_Orchestrator -- "uses" --> NCBI_Entrez_Agent
+
+    SRAgent_Orchestrator -- "uses" --> Dataset_Discovery_Agent
+
+    SRAgent_Orchestrator -- "uses" --> Tissue_Ontology_Agent
+
+    SRAgent_Orchestrator -- "uses" --> BigQuery_Integration_Agent
+
+    SRAgent_Orchestrator -- "uses" --> Sequence_Analysis_Agent
+
+    NCBI_Entrez_Agent -- "uses" --> External_Service_Integration
+
+    Dataset_Discovery_Agent -- "uses" --> External_Service_Integration
+
+    Tissue_Ontology_Agent -- "uses" --> External_Service_Integration
+
+    BigQuery_Integration_Agent -- "uses" --> External_Service_Integration
+
+    Sequence_Analysis_Agent -- "uses" --> External_Service_Integration
+
+    SRAgent_Orchestrator -- "uses" --> Agent_Utilities
+
+    NCBI_Entrez_Agent -- "uses" --> Agent_Utilities
+
+    Dataset_Discovery_Agent -- "uses" --> Agent_Utilities
+
+    Tissue_Ontology_Agent -- "uses" --> Agent_Utilities
+
+    BigQuery_Integration_Agent -- "uses" --> Agent_Utilities
+
+    Sequence_Analysis_Agent -- "uses" --> Agent_Utilities
+
+    Agent_Output_Formatter -- "uses" --> Agent_Utilities
+
+    SRAgent_Orchestrator -- "uses" --> Agent_Output_Formatter
+
+    NCBI_Entrez_Agent -- "uses" --> Agent_Output_Formatter
+
+    Dataset_Discovery_Agent -- "uses" --> Agent_Output_Formatter
+
+    Tissue_Ontology_Agent -- "uses" --> Agent_Output_Formatter
+
+    BigQuery_Integration_Agent -- "uses" --> Agent_Output_Formatter
+
+    Sequence_Analysis_Agent -- "uses" --> Agent_Output_Formatter
+
+    Agent_Utilities -- "uses" --> Agent_Output_Formatter
+
+    click Workflow_Orchestrator href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//Workflow_Orchestrator.md" "Details"
+
+    click External_Service_Integration href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//External_Service_Integration.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The Core AI Agents component is the intelligent backbone of the system, encapsulating the LLM-driven reasoning and decision-making logic for specialized bioinformatics tasks. It comprises various specialized agents, each designed to handle specific aspects of data curation and retrieval. These agents leverage External Service Integration tools to perform atomic operations and contribute to complex bioinformatics workflows. These components are fundamental because they embody the "Agent-Oriented Architecture" of the project. Each agent is a specialized, LLM-driven entity responsible for a distinct set of bioinformatics tasks, promoting modularity and reusability. Their interactions demonstrate the "Orchestration Pattern" where the SRAgent Orchestrator coordinates the activities of other agents, and the "Tool-Use/Function Calling" pattern as they all rely on External Service Integration to interact with the outside world. This clear separation of concerns makes the system scalable, maintainable, and adaptable to new bioinformatics challenges.
+
+
+
+### SRAgent Orchestrator
+
+The primary agent responsible for orchestrating high-level, SRA-specific bioinformatics workflows and coordinating tasks among other specialized agents. It acts as the central control point for SRA data curation and retrieval processes.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `SRAgent Orchestrator` (1:1)
+
+
+
+
+
+### NCBI Entrez Agent
+
+Manages all interactions with the NCBI Entrez suite of databases. This includes performing searches (ESearch), fetching detailed records (EFetch), linking related entries (ELink), summarizing results (ESummary), and converting data formats.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `NCBI Entrez Agent` (1:1)
+
+- `NCBI Entrez Agent` (1:1)
+
+- `NCBI Entrez Agent` (1:1)
+
+- `NCBI Entrez Agent` (1:1)
+
+- `NCBI Entrez Agent` (1:1)
+
+- `NCBI Entrez Agent` (1:1)
+
+- `NCBI Entrez Agent` (1:1)
+
+
+
+
+
+### Dataset Discovery Agent
+
+Specializes in identifying and locating relevant bioinformatics datasets based on user queries or internal logic. It leverages various tools to search for and filter datasets across different sources.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Dataset Discovery Agent` (1:1)
+
+
+
+
+
+### Tissue Ontology Agent
+
+Handles the processing, interpretation, and application of tissue-related ontological information. This agent ensures consistency and accuracy in classifying and retrieving data based on tissue types.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Tissue Ontology Agent` (1:1)
+
+
+
+
+
+### BigQuery Integration Agent
+
+Facilitates direct interaction with Google Cloud BigQuery for querying and retrieving large-scale bioinformatics datasets stored within the BigQuery environment.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `BigQuery Integration Agent` (1:1)
+
+
+
+
+
+### Sequence Analysis Agent
+
+Focuses on tasks related to the processing, manipulation, and basic analysis of biological sequence data (e.g., DNA, RNA, protein sequences).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Sequence Analysis Agent` (1:1)
+
+
+
+
+
+### Agent Output Formatter
+
+Responsible for formatting and displaying the progress, intermediate results, and final outputs of the various agents in a user-friendly and consistent manner.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Agent Output Formatter` (1:1)
+
+
+
+
+
+### Agent Utilities
+
+Provides a collection of common helper functions, reusable logic, and utility methods that support the operations of multiple agents within the subsystem.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Agent Utilities` (1:1)
+
+
+
+
+
+### Workflow Orchestrator [[Expand]](./Workflow_Orchestrator.md)
+
+Manages overall bioinformatics workflows.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### External Service Integration [[Expand]](./External_Service_Integration.md)
+
+Provides tools for interacting with external APIs and services.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data_Persistence_Layer.md
+++ b/.codeboarding/Data_Persistence_Layer.md
@@ -1,0 +1,229 @@
+```mermaid
+
+graph LR
+
+    Data_Persistence_Layer["Data Persistence Layer"]
+
+    SRAgent_db_connect["SRAgent.db.connect"]
+
+    SRAgent_db_create["SRAgent.db.create"]
+
+    SRAgent_db_get["SRAgent.db.get"]
+
+    SRAgent_db_update["SRAgent.db.update"]
+
+    SRAgent_db_upsert["SRAgent.db.upsert"]
+
+    SRAgent_db_fix["SRAgent.db.fix"]
+
+    SRAgent_db_utils["SRAgent.db.utils"]
+
+    SRAgent_db_create -- "depends on" --> SRAgent_db_connect
+
+    SRAgent_db_get -- "depends on" --> SRAgent_db_connect
+
+    SRAgent_db_update -- "depends on" --> SRAgent_db_connect
+
+    SRAgent_db_upsert -- "depends on" --> SRAgent_db_connect
+
+    SRAgent_db_fix -- "depends on" --> SRAgent_db_connect
+
+    SRAgent_db_create -- "utilizes" --> SRAgent_db_utils
+
+    SRAgent_db_get -- "utilizes" --> SRAgent_db_utils
+
+    SRAgent_db_update -- "utilizes" --> SRAgent_db_utils
+
+    SRAgent_db_upsert -- "utilizes" --> SRAgent_db_utils
+
+    SRAgent_db_fix -- "utilizes" --> SRAgent_db_utils
+
+    SRAgent_cli_srx_info -- "utilizes" --> Data_Persistence_Layer
+
+    SRAgent_workflows_find_datasets -- "interacts with" --> Data_Persistence_Layer
+
+    SRAgent_workflows_metadata -- "employs" --> Data_Persistence_Layer
+
+    SRAgent_workflows_srx_info -- "leverages" --> Data_Persistence_Layer
+
+    click Data_Persistence_Layer href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//Data_Persistence_Layer.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Data Persistence Layer` and its sub-components (`SRAgent.db.connect`, `SRAgent.db.create`, `SRAgent.db.get`, `SRAgent.db.update`, `SRAgent.db.upsert`, `SRAgent.db.fix`, `SRAgent.db.utils`) are fundamental to the AI Agent-based Bioinformatics Data Curation and Retrieval System for the following reasons:
+
+
+
+1.  **Core Data Management**: As an AI agent system dealing with bioinformatics data, the ability to reliably store, retrieve, and manage large volumes of structured and semi-structured data is paramount. This layer provides the essential infrastructure for all data operations.
+
+2.  **Abstraction and Decoupling**: By abstracting the underlying PostgreSQL database interactions, this layer decouples the business logic (agents, workflows) from the specifics of database technology. This promotes modularity, makes the system easier to maintain, and allows for potential database changes without impacting other components significantly.
+
+3.  **Data Consistency and Integrity**: Dedicated modules for creation, retrieval, updates, upserts, and fixes ensure that data is handled consistently and that its integrity is maintained throughout its lifecycle within the system. This is critical for bioinformatics data, where accuracy is vital.
+
+4.  **Efficiency and Performance**: The `connect` module, by managing connections, likely contributes to efficient resource utilization (e.g., connection pooling). The `upsert` functionality is particularly useful for optimizing data ingestion processes common in data curation.
+
+5.  **Reusability**: The `utils` module centralizes common database helper functions, preventing code duplication and ensuring a consistent approach to database interactions across the entire persistence layer.
+
+6.  **Support for Agent Operations**: AI agents often need to store intermediate results, retrieve historical data for context, or persist curated information. This persistence layer directly supports these needs, enabling the agents to perform complex, multi-step reasoning and data processing tasks effectively. For example, the `SRAgent.workflows.find_datasets` and `SRAgent.workflows.metadata` components heavily rely on this layer to store and retrieve information about datasets and their associated metadata.
+
+
+
+### Data Persistence Layer [[Expand]](./Data_Persistence_Layer.md)
+
+This component is responsible for all persistent data storage and retrieval operations, primarily interacting with a PostgreSQL database. It provides a robust abstraction over raw database interactions, managing connection pooling, schema creation, and CRUD (Create, Read, Update, Delete) operations for various data entities. It ensures data consistency and integrity across the system, abstracting the underlying database interactions from other components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `SRAgent.db`
+
+
+
+
+
+### SRAgent.db.connect
+
+Manages the establishment and maintenance of connections to the PostgreSQL database. It handles connection pooling and ensures that other database operations have a stable and efficient way to interact with the database.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/connect.py" target="_blank" rel="noopener noreferrer">`SRAgent.db.connect`</a>
+
+
+
+
+
+### SRAgent.db.create
+
+Handles the insertion of new data records into the database. This includes defining the schema for new entries and executing the necessary SQL commands to persist data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/create.py" target="_blank" rel="noopener noreferrer">`SRAgent.db.create`</a>
+
+
+
+
+
+### SRAgent.db.get
+
+Provides functionalities for retrieving data from the database based on specified criteria. It abstracts the querying process, allowing other components to fetch data without direct SQL knowledge.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/get.py" target="_blank" rel="noopener noreferrer">`SRAgent.db.get`</a>
+
+
+
+
+
+### SRAgent.db.update
+
+Manages the modification of existing data records in the database. It ensures that updates are applied correctly and efficiently, maintaining data integrity.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/update.py" target="_blank" rel="noopener noreferrer">`SRAgent.db.update`</a>
+
+
+
+
+
+### SRAgent.db.upsert
+
+Implements a combined "update or insert" operation, allowing for atomic creation or modification of records. This is particularly useful for data synchronization and avoiding duplicate entries.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/upsert.py" target="_blank" rel="noopener noreferrer">`SRAgent.db.upsert`</a>
+
+
+
+
+
+### SRAgent.db.fix
+
+Contains logic for data integrity checks and potential repair operations within the database. This component helps in maintaining the quality and consistency of stored bioinformatics data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/fix.py" target="_blank" rel="noopener noreferrer">`SRAgent.db.fix`</a>
+
+
+
+
+
+### SRAgent.db.utils
+
+Provides a collection of utility functions and helper methods used across various database operations. This promotes code reusability and consistency in database interactions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/utils.py" target="_blank" rel="noopener noreferrer">`SRAgent.db.utils`</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/External_Service_Integration.md
+++ b/.codeboarding/External_Service_Integration.md
@@ -1,0 +1,305 @@
+```mermaid
+
+graph LR
+
+    External_Service_Integration["External Service Integration"]
+
+    SRAgent_tools_esearch["SRAgent.tools.esearch"]
+
+    SRAgent_tools_efetch["SRAgent.tools.efetch"]
+
+    SRAgent_tools_elink["SRAgent.tools.elink"]
+
+    SRAgent_tools_esummary["SRAgent.tools.esummary"]
+
+    SRAgent_tools_ncbi_fetch["SRAgent.tools.ncbi_fetch"]
+
+    SRAgent_tools_entrez_db["SRAgent.tools.entrez_db"]
+
+    SRAgent_tools_sequences["SRAgent.tools.sequences"]
+
+    SRAgent_tools_bigquery["SRAgent.tools.bigquery"]
+
+    SRAgent_tools_tissue_ontology["SRAgent.tools.tissue_ontology"]
+
+    SRAgent_tools_utils["SRAgent.tools.utils"]
+
+    AI_Agents["AI Agents"]
+
+    Workflows["Workflows"]
+
+    AI_Agents -- "utilizes" --> External_Service_Integration
+
+    Workflows -- "orchestrates calls to" --> External_Service_Integration
+
+    External_Service_Integration -- "provides data to" --> AI_Agents
+
+    External_Service_Integration -- "provides data to" --> Workflows
+
+    External_Service_Integration -- "interacts with" --> External_Bioinformatics_APIs_Services
+
+    click External_Service_Integration href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//External_Service_Integration.md" "Details"
+
+    click AI_Agents href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//AI_Agents.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This component provides a standardized and abstracted interface for interacting with various external bioinformatics APIs and services. It encapsulates the logic for querying and retrieving data from sources such as NCBI Entrez databases (e.g., PubMed, SRA), Google Cloud BigQuery for large-scale data, and the UBERON tissue ontology service for standardized biological annotations. It acts as a crucial wrapper, simplifying external interactions for other components like AI agents and workflows.
+
+
+
+### External Service Integration [[Expand]](./External_Service_Integration.md)
+
+This component provides a standardized and abstracted interface for interacting with various external bioinformatics APIs and services. It encapsulates the logic for querying and retrieving data from sources such as NCBI Entrez databases (e.g., PubMed, SRA), Google Cloud BigQuery for large-scale data, and the UBERON tissue ontology service for standardized biological annotations. It acts as a crucial wrapper, simplifying external interactions for other components like AI agents and workflows.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/esearch.py#L180-L250" target="_blank" rel="noopener noreferrer">`SRAgent.tools.esearch` (180:250)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/efetch.py#L15-L68" target="_blank" rel="noopener noreferrer">`SRAgent.tools.efetch` (15:68)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/elink.py#L44-L129" target="_blank" rel="noopener noreferrer">`SRAgent.tools.elink` (44:129)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/esummary.py#L13-L69" target="_blank" rel="noopener noreferrer">`SRAgent.tools.esummary` (13:69)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/ncbi_fetch.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.ncbi_fetch` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/entrez_db.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.entrez_db` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/sequences.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.sequences` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/bigquery.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.bigquery` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/tissue_ontology.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.tissue_ontology` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.utils` (1:1)</a>
+
+
+
+
+
+### SRAgent.tools.esearch
+
+Handles search queries against NCBI Entrez databases (e.g., SRA, PubMed, GEO). It's crucial for initiating data retrieval by identifying relevant entries based on user queries.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/esearch.py#L180-L250" target="_blank" rel="noopener noreferrer">`SRAgent.tools.esearch` (180:250)</a>
+
+
+
+
+
+### SRAgent.tools.efetch
+
+Retrieves full records from NCBI Entrez databases based on IDs obtained from `esearch` or other means. This is vital for getting detailed information about biological entities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/efetch.py#L15-L68" target="_blank" rel="noopener noreferrer">`SRAgent.tools.efetch` (15:68)</a>
+
+
+
+
+
+### SRAgent.tools.elink
+
+Facilitates linking between related entries across different NCBI Entrez databases. This is essential for navigating the interconnectedness of biological data (e.g., linking a SRA experiment to a PubMed article).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/elink.py#L44-L129" target="_blank" rel="noopener noreferrer">`SRAgent.tools.elink` (44:129)</a>
+
+
+
+
+
+### SRAgent.tools.esummary
+
+Retrieves summaries of records from NCBI Entrez databases. This is useful for quickly getting an overview of an entry without fetching the entire detailed record.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/esummary.py#L13-L69" target="_blank" rel="noopener noreferrer">`SRAgent.tools.esummary` (13:69)</a>
+
+
+
+
+
+### SRAgent.tools.ncbi_fetch
+
+A more general-purpose tool for fetching data from NCBI, potentially encapsulating or orchestrating calls to `esearch`, `efetch`, `elink`, and `esummary` for more complex NCBI interactions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/ncbi_fetch.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.ncbi_fetch` (1:1)</a>
+
+
+
+
+
+### SRAgent.tools.entrez_db
+
+Likely provides utilities or configurations related to managing and interacting with different Entrez databases, such as listing available databases or setting up database-specific parameters.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/entrez_db.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.entrez_db` (1:1)</a>
+
+
+
+
+
+### SRAgent.tools.sequences
+
+Focuses on retrieving and potentially processing biological sequence data, likely from NCBI or other sequence repositories.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/sequences.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.sequences` (1:1)</a>
+
+
+
+
+
+### SRAgent.tools.bigquery
+
+Provides an interface for querying and retrieving data from Google Cloud BigQuery, enabling access to large-scale public or private bioinformatics datasets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/bigquery.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.bigquery` (1:1)</a>
+
+
+
+
+
+### SRAgent.tools.tissue_ontology
+
+Interacts with the UBERON tissue ontology service, allowing for standardized annotation and retrieval of information based on anatomical structures and tissues.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/tissue_ontology.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.tissue_ontology` (1:1)</a>
+
+
+
+
+
+### SRAgent.tools.utils
+
+Contains common utility functions used across various external service interactions, such as XML parsing, error handling, or request formatting.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.utils` (1:1)</a>
+
+
+
+
+
+### AI Agents [[Expand]](./AI_Agents.md)
+
+AI agents (e.g., Entrez Agent, SRAgent Agent, Tissue-ontology Agent, Find-datasets Agent) that utilize external service integration.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Workflows
+
+Workflows (e.g., Convert Workflow, Find Datasets Workflow, Metadata Workflow, SRX Info Workflow) that orchestrate calls to external service integration.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/System_Utilities_Support_Scripts.md
+++ b/.codeboarding/System_Utilities_Support_Scripts.md
@@ -1,0 +1,215 @@
+```mermaid
+
+graph LR
+
+    Core_Utility_Functions["Core Utility Functions"]
+
+    Configuration_Management["Configuration Management"]
+
+    Database_Management_Layer["Database Management Layer"]
+
+    Shared_Data_Models_Biological_Ontologies["Shared Data Models & Biological Ontologies"]
+
+    Data_Search_Discovery["Data Search & Discovery"]
+
+    Command_Line_Interface_CLI_Application_Layer["Command Line Interface (CLI) Application Layer"]
+
+    System_Evaluation_Framework["System Evaluation Framework"]
+
+    Command_Line_Interface_CLI_Application_Layer -- "utilizes" --> Database_Management_Layer
+
+    Command_Line_Interface_CLI_Application_Layer -- "utilizes" --> Data_Search_Discovery
+
+    Database_Management_Layer -- "relies on" --> Configuration_Management
+
+    Data_Search_Discovery -- "utilizes" --> Shared_Data_Models_Biological_Ontologies
+
+    Shared_Data_Models_Biological_Ontologies -- "relies on" --> Configuration_Management
+
+    System_Evaluation_Framework -- "utilizes" --> Database_Management_Layer
+
+    System_Evaluation_Framework -- "utilizes" --> Shared_Data_Models_Biological_Ontologies
+
+    Core_Utility_Functions -- "relies on" --> Configuration_Management
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The System Utilities & Support Scripts component serves as the foundational backbone of the SRAgent project, providing essential shared functionalities, configuration management, and operational scripts. It encapsulates general data manipulation, command execution, initial data ingestion, format transformations, database administration, metadata enrichment, dataset discovery, and the evaluation framework. These components are fundamental because they embody the project's architectural principles of modularity, reusability, and abstraction. They ensure that core functionalities are centralized, configurable, and accessible, supporting the complex operations of an AI Agent-based Bioinformatics Data Curation and Retrieval System.
+
+
+
+### Core Utility Functions
+
+A collection of foundational, shared helper functions for general data manipulation, string processing, and other common operations used across the entire system. These functions ensure code reusability and consistency.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/utils.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/tools/utils.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/agents/utils.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/db/utils.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/cli/utils.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/workflows/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/workflows/utils.py` (1:1)</a>
+
+
+
+
+
+### Configuration Management
+
+Manages application settings, API keys, database credentials, and other configurable parameters. This component is crucial for ensuring secure, flexible, and environment-agnostic deployment of the system.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `SRAgent/settings.yml` (1:1)
+
+
+
+
+
+### Database Management Layer
+
+Encapsulates all interactions with the PostgreSQL database. It provides functionalities for connection, schema creation, data retrieval, insertion/updating (upsert), and general database administration tasks, supporting initial data ingestion and ongoing data management.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/__init__.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/db/__init__.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/connect.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/db/connect.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/create.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/db/create.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/fix.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/db/fix.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/get.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/db/get.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/update.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/db/update.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/upsert.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/db/upsert.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/db/utils.py` (1:1)</a>
+
+
+
+
+
+### Shared Data Models & Biological Ontologies
+
+Defines data structures for biological entities and manages organism-related data. This includes the integration and embedding of biological ontologies (e.g., Uberon), which is crucial for metadata enrichment and providing a structured basis for biological data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/organisms.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/organisms.py` (1:1)</a>
+
+
+
+
+
+### Data Search & Discovery
+
+Provides mechanisms and interfaces for searching, querying, and discovering datasets and associated metadata within the system. It leverages structured data and potentially integrates with external search services to enable efficient data access.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/search.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/search.py` (1:1)</a>
+
+
+
+
+
+### Command Line Interface (CLI) Application Layer
+
+The primary user-facing component that provides command-line entry points for various operations. It parses user arguments and orchestrates calls to underlying workflows, agents, and utility scripts, effectively serving as the execution environment for many standalone support scripts.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/__init__.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/cli/__init__.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/__main__.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/cli/__main__.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/entrez.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/cli/entrez.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/find_datasets.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/cli/find_datasets.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/metadata.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/cli/metadata.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/sragent.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/cli/sragent.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/srx_info.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/cli/srx_info.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/tissue_ontology.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/cli/tissue_ontology.py` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent/cli/utils.py` (1:1)</a>
+
+
+
+
+
+### System Evaluation Framework
+
+Provides tools and methodologies for evaluating the performance, accuracy, and effectiveness of the system's components, particularly the AI agents and data curation processes. This is vital for continuous improvement and validation.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/User_Interface_CLI_.md
+++ b/.codeboarding/User_Interface_CLI_.md
@@ -1,0 +1,261 @@
+```mermaid
+
+graph LR
+
+    User_Interface_CLI_["User Interface (CLI)"]
+
+    SRAgent_cli___main__["SRAgent.cli.__main__"]
+
+    SRAgent_cli_utils["SRAgent.cli.utils"]
+
+    SRAgent_cli_entrez["SRAgent.cli.entrez"]
+
+    SRAgent_cli_find_datasets["SRAgent.cli.find_datasets"]
+
+    SRAgent_cli_metadata["SRAgent.cli.metadata"]
+
+    SRAgent_cli_sragent["SRAgent.cli.sragent"]
+
+    SRAgent_cli_srx_info["SRAgent.cli.srx_info"]
+
+    SRAgent_cli_tissue_ontology["SRAgent.cli.tissue_ontology"]
+
+    User_Interface_CLI_ -- "contains" --> SRAgent_cli___main__
+
+    User_Interface_CLI_ -- "contains" --> SRAgent_cli_utils
+
+    SRAgent_cli___main__ -- "orchestrates calls to" --> SRAgent_cli_entrez
+
+    SRAgent_cli___main__ -- "orchestrates calls to" --> SRAgent_cli_find_datasets
+
+    SRAgent_cli___main__ -- "orchestrates calls to" --> SRAgent_cli_metadata
+
+    SRAgent_cli___main__ -- "orchestrates calls to" --> SRAgent_cli_sragent
+
+    SRAgent_cli___main__ -- "orchestrates calls to" --> SRAgent_cli_srx_info
+
+    SRAgent_cli___main__ -- "orchestrates calls to" --> SRAgent_cli_tissue_ontology
+
+    SRAgent_cli_utils -- "provides utilities to" --> SRAgent_cli_entrez
+
+    SRAgent_cli_utils -- "provides utilities to" --> SRAgent_cli_find_datasets
+
+    SRAgent_cli_utils -- "provides utilities to" --> SRAgent_cli_metadata
+
+    SRAgent_cli_utils -- "provides utilities to" --> SRAgent_cli_sragent
+
+    SRAgent_cli_utils -- "provides utilities to" --> SRAgent_cli_srx_info
+
+    SRAgent_cli_utils -- "provides utilities to" --> SRAgent_cli_tissue_ontology
+
+    SRAgent_cli_entrez -- "utilizes" --> SRAgent_cli_utils
+
+    SRAgent_cli_entrez -- "initiates" --> Entrez_Agent
+
+    SRAgent_cli_find_datasets -- "utilizes" --> SRAgent_cli_utils
+
+    SRAgent_cli_find_datasets -- "initiates" --> SRAgent_workflows_find_datasets
+
+    SRAgent_cli_metadata -- "utilizes" --> SRAgent_cli_utils
+
+    SRAgent_cli_metadata -- "initiates" --> SRAgent_workflows_metadata
+
+    SRAgent_cli_sragent -- "utilizes" --> SRAgent_cli_utils
+
+    SRAgent_cli_sragent -- "initiates" --> SRAgent_Agent
+
+    SRAgent_cli_srx_info -- "utilizes" --> SRAgent_cli_utils
+
+    SRAgent_cli_srx_info -- "initiates" --> SRAgent_workflows_srx_info
+
+    SRAgent_cli_srx_info -- "interacts with" --> SRAgent_db
+
+    SRAgent_cli_tissue_ontology -- "utilizes" --> SRAgent_cli_utils
+
+    SRAgent_cli_tissue_ontology -- "initiates" --> SRAgent_workflows_tissue_ontology
+
+    click User_Interface_CLI_ href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//User_Interface_CLI_.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The User Interface (CLI) subsystem serves as the primary interactive gateway for users to engage with the SRAgent system. It is meticulously designed to parse user commands, validate inputs, and subsequently trigger the appropriate bioinformatics data curation and retrieval workflows. This component embodies the Command Line Interface (CLI) Application architectural pattern, providing a robust and user-friendly command-line experience.
+
+
+
+### User Interface (CLI) [[Expand]](./User_Interface_CLI_.md)
+
+The overarching component that provides the interactive command-line experience. It is responsible for the overall structure and flow of user interactions, encompassing all sub-commands and utilities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `SRAgent.cli` (1:1)
+
+
+
+
+
+### SRAgent.cli.__main__
+
+This is the core entry point of the CLI application. It is responsible for setting up the command-line argument parser, defining the available top-level commands, and dispatching control to the relevant command-specific modules based on user input. It acts as the central orchestrator for all CLI interactions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/__main__.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.__main__` (1:1)</a>
+
+
+
+
+
+### SRAgent.cli.utils
+
+This module provides a collection of common utility functions that are leveraged by various command-specific modules within the `SRAgent.cli` package. These utilities include functions for argument parsing, input validation, output formatting, and other helper functionalities that promote code reusability and consistency across the CLI.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.utils` (1:1)</a>
+
+
+
+
+
+### SRAgent.cli.entrez
+
+Encapsulates the logic for handling Entrez-specific user commands. It parses arguments relevant to Entrez operations, performs necessary input validation, and initiates the corresponding `Entrez Agent` or related workflows to interact with the Entrez database.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/entrez.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.entrez` (1:1)</a>
+
+
+
+
+
+### SRAgent.cli.find_datasets
+
+Manages commands for discovering and retrieving datasets. It parses arguments, validates input, and initiates the `Find-datasets Agent` or the `SRAgent.workflows.find_datasets` workflow to fulfill the user's request.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/find_datasets.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.find_datasets` (1:1)</a>
+
+
+
+
+
+### SRAgent.cli.metadata
+
+Handles commands related to metadata curation and retrieval. It parses arguments, validates input, and initiates the `Metadata Agent` or the `SRAgent.workflows.metadata` workflow to process metadata-related queries.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/metadata.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.metadata` (1:1)</a>
+
+
+
+
+
+### SRAgent.cli.sragent
+
+Encapsulates the logic for general SRAgent commands that might not fall under specific categories like Entrez or SRX info. It parses arguments, validates input, and initiates the core `SRAgent Agent` or related workflows.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/sragent.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.sragent` (1:1)</a>
+
+
+
+
+
+### SRAgent.cli.srx_info
+
+Manages commands for retrieving detailed information about SRX (SRA Experiment) accessions. It parses arguments, validates input, and initiates the `SRX-info Agent` or the `SRAgent.workflows.srx_info` workflow, potentially interacting with the database for data retrieval.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/srx_info.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.srx_info` (1:1)</a>
+
+
+
+
+
+### SRAgent.cli.tissue_ontology
+
+Handles commands related to tissue ontology, likely for mapping or querying tissue-specific data. It parses arguments, validates input, and initiates the `Tissue-ontology Agent` or the `SRAgent.workflows.tissue_ontology` workflow.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/tissue_ontology.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.tissue_ontology` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,285 @@
+```mermaid
+
+graph LR
+
+    User_Interface_CLI_["User Interface (CLI)"]
+
+    Agent_Workflow_Orchestrator["Agent Workflow Orchestrator"]
+
+    Core_AI_Agents["Core AI Agents"]
+
+    External_Service_Integration["External Service Integration"]
+
+    Data_Persistence_Layer["Data Persistence Layer"]
+
+    System_Utilities_Support_Scripts["System Utilities & Support Scripts"]
+
+    User_Interface_CLI_ -- "initiates and receives output from" --> Agent_Workflow_Orchestrator
+
+    Agent_Workflow_Orchestrator -- "coordinates and invokes" --> Core_AI_Agents
+
+    Agent_Workflow_Orchestrator -- "interacts with for workflow state" --> Data_Persistence_Layer
+
+    Agent_Workflow_Orchestrator -- "utilizes" --> System_Utilities_Support_Scripts
+
+    Core_AI_Agents -- "utilize for external data access" --> External_Service_Integration
+
+    Core_AI_Agents -- "interact with for agent-specific data" --> Data_Persistence_Layer
+
+    Core_AI_Agents -- "leverage for common functions" --> System_Utilities_Support_Scripts
+
+    Core_AI_Agents -- "reports results back to" --> Agent_Workflow_Orchestrator
+
+    External_Service_Integration -- "relies on for configuration and common helpers" --> System_Utilities_Support_Scripts
+
+    Data_Persistence_Layer -- "leverages for database-specific utilities" --> System_Utilities_Support_Scripts
+
+    System_Utilities_Support_Scripts -- "manages and populates" --> Data_Persistence_Layer
+
+    System_Utilities_Support_Scripts -- "may fetch raw data using" --> External_Service_Integration
+
+    click User_Interface_CLI_ href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//User_Interface_CLI_.md" "Details"
+
+    click Agent_Workflow_Orchestrator href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//Agent_Workflow_Orchestrator.md" "Details"
+
+    click Core_AI_Agents href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//Core_AI_Agents.md" "Details"
+
+    click External_Service_Integration href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//External_Service_Integration.md" "Details"
+
+    click Data_Persistence_Layer href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//Data_Persistence_Layer.md" "Details"
+
+    click System_Utilities_Support_Scripts href "https://github.com/ArcInstitute/SRAgent/blob/main/.codeboarding//System_Utilities_Support_Scripts.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `SRAgent` project, an AI Agent-based Bioinformatics Data Curation and Retrieval System, is architected around a modular design with a clear separation of concerns. The system leverages an agent-oriented approach, orchestrating various AI agents and specialized tools to interact with external bioinformatics services and manage internal data.
+
+
+
+### User Interface (CLI) [[Expand]](./User_Interface_CLI_.md)
+
+The primary entry point for users, responsible for parsing commands, validating inputs, and initiating specific data curation and retrieval workflows. It provides the interactive command-line experience.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/__main__.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.__main__` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/entrez.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.entrez` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/sragent.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.sragent` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/metadata.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.metadata` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/tissue_ontology.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.tissue_ontology` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/srx_info.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.srx_info` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/find_datasets.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.find_datasets` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/cli/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.cli.utils` (1:1)</a>
+
+
+
+
+
+### Agent Workflow Orchestrator [[Expand]](./Agent_Workflow_Orchestrator.md)
+
+Orchestrates complex, multi-step data curation and retrieval processes. It defines the sequence of operations, coordinates the execution of various `Core AI Agents`, and manages their interactions to achieve high-level bioinformatics tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/workflows/find_datasets.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.workflows.find_datasets` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/workflows/metadata.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.workflows.metadata` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/workflows/tissue_ontology.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.workflows.tissue_ontology` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/workflows/srx_info.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.workflows.srx_info` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/workflows/convert.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.workflows.convert` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/workflows/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.workflows.utils` (1:1)</a>
+
+
+
+
+
+### Core AI Agents [[Expand]](./Core_AI_Agents.md)
+
+Encapsulates the LLM-driven reasoning and decision-making logic for specialized bioinformatics tasks. Each agent leverages `External Service Integration` tools to perform atomic operations and contributes to the overall workflow. This component also handles formatting and displaying agent progress.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/sragent.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.sragent` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/entrez.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.entrez` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/find_datasets.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.find_datasets` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/tissue_ontology.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.tissue_ontology` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/ncbi_fetch.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.ncbi_fetch` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/esearch.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.esearch` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/efetch.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.efetch` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/elink.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.elink` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/esummary.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.esummary` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/bigquery.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.bigquery` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/sequences.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.sequences` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/entrez_convert.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.entrez_convert` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/display.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.display` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/agents/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.agents.utils` (1:1)</a>
+
+
+
+
+
+### External Service Integration [[Expand]](./External_Service_Integration.md)
+
+Provides a standardized and abstracted interface for interacting with various external bioinformatics APIs and services. This includes NCBI Entrez databases, SRA data processing utilities, Google Cloud BigQuery, and the UBERON tissue ontology service. It acts as a wrapper for external interactions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/esearch.py#L180-L250" target="_blank" rel="noopener noreferrer">`SRAgent.tools.esearch` (180:250)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/efetch.py#L15-L68" target="_blank" rel="noopener noreferrer">`SRAgent.tools.efetch` (15:68)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/elink.py#L44-L129" target="_blank" rel="noopener noreferrer">`SRAgent.tools.elink` (44:129)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/esummary.py#L13-L69" target="_blank" rel="noopener noreferrer">`SRAgent.tools.esummary` (13:69)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/ncbi_fetch.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.ncbi_fetch` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/entrez_db.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.entrez_db` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/sequences.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.sequences` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/bigquery.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.bigquery` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/tissue_ontology.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.tissue_ontology` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/tools/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.tools.utils` (1:1)</a>
+
+
+
+
+
+### Data Persistence Layer [[Expand]](./Data_Persistence_Layer.md)
+
+Manages all persistent data storage and retrieval operations, primarily with the PostgreSQL database. It handles connection management, schema creation, data insertion, updates, and querying, abstracting the underlying database interactions from other components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/connect.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.db.connect` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/create.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.db.create` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/get.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.db.get` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/update.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.db.update` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/upsert.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.db.upsert` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.db.utils` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/db/fix.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.db.fix` (1:1)</a>
+
+
+
+
+
+### System Utilities & Support Scripts [[Expand]](./System_Utilities_Support_Scripts.md)
+
+A collection of foundational shared helper functions, configuration management, and standalone scripts. This includes general data manipulation, command execution, initial data ingestion, format transformations, database administration, metadata enrichment, dataset discovery, and the evaluation framework.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.utils` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/organisms.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.organisms` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/SRAgent/search.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.search` (1:1)</a>
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/scripts/acc2srr.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.scripts.acc2srr` (1:1)</a>
+
+- `SRAgent.scripts.uberon_obo_embed` (1:1)
+
+- `SRAgent.scripts.obs_csv_to_parquet` (1:1)
+
+- `SRAgent.scripts.h5ad_to_parquet` (1:1)
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/scripts/bioproject2srx.py#L1-L1" target="_blank" rel="noopener noreferrer">`SRAgent.scripts.bioproject2srx` (1:1)</a>
+
+- `SRAgent.scripts.db_tools` (1:1)
+
+- `SRAgent.scripts.add_tissue_ontology` (1:1)
+
+- `SRAgent.scripts.get_srx_date` (1:1)
+
+- `SRAgent.scripts.dataset_finder` (1:1)
+
+- <a href="https://github.com/ArcInstitute/SRAgent/blob/main/scripts/eval.py#L160-L228" target="_blank" rel="noopener noreferrer">`SRAgent.scripts.eval` (160:228)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR adds documents with Mermaid diagrams that provide a high-level overview of the codebase. You can see an example here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/SRAgent/on_boarding.md

The goal is to make it easier for people to modify and use the SRAgents codebase. A friend and I are working on improving the "getting to know the code" phase, especially for scientists who use code as a tool but aren't software engineers.

I would love to hear your feedback on the diagrams! If you like them, we can merge this PR and I can also integrate our free Github Action which will keep them up-to-date.

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.