### PR TITLE
Defer BigQuery client creation and improve error handling

### DIFF
--- a/SRAgent/agents/bigquery.py
+++ b/SRAgent/agents/bigquery.py
@@ -1,6 +1,7 @@
 # import
 ## batteries
 import asyncio
+import sys
 from typing import Annotated, Callable, Optional
 
 ## 3rd party
@@ -98,6 +99,12 @@ def create_bigquery_agent(model_name: Optional[str] = None) -> Callable:
                     "Enable one of: (1) 'gcloud auth application-default login' and set 'GCP_PROJECT_ID', "
                     "or (2) set 'GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json' and 'GCP_PROJECT_ID'. "
                     "Without credentials, BigQuery tools cannot run."
+                )
+                print(
+                    "WARNING: BigQuery not used — missing Google Cloud credentials.\n"
+                    "- Run: gcloud auth application-default login (and set GCP_PROJECT_ID), or\n"
+                    "- Set: GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json and GCP_PROJECT_ID",
+                    file=sys.stderr,
                 )
                 return {
                     "messages": [AIMessage(content=guidance, name="bigquery_agent")]

--- a/SRAgent/agents/bigquery.py
+++ b/SRAgent/agents/bigquery.py
@@ -32,8 +32,8 @@ def create_bigquery_agent(model_name: Optional[str] = None) -> Callable:
     # create model
     model = set_model(model_name=model_name, agent_name="bigquery")
 
-    # init client
-    bq_client = bigquery.Client()
+    # Defer BigQuery client creation so missing ADC doesn't crash workflows
+    bq_client = None
 
     # set tools
     tools = [
@@ -87,8 +87,24 @@ def create_bigquery_agent(model_name: Optional[str] = None) -> Callable:
         Invoke the BigQuery agent with a message.
         The BigQuery agent will search the SRA database with BigQuery.
         """
-        # Create config with client if not present
-        config = {"configurable": {"client": bq_client}}
+        # Ensure BigQuery client; if unavailable, return helpful guidance
+        client = bq_client
+        if client is None:
+            try:
+                client = bigquery.Client()
+            except Exception:
+                guidance = (
+                    "BigQuery requires Google Cloud credentials. "
+                    "Enable one of: (1) 'gcloud auth application-default login' and set 'GCP_PROJECT_ID', "
+                    "or (2) set 'GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json' and 'GCP_PROJECT_ID'. "
+                    "Without credentials, BigQuery tools cannot run."
+                )
+                return {
+                    "messages": [AIMessage(content=guidance, name="bigquery_agent")]
+                }
+
+        # Create config with client
+        config = {"configurable": {"client": client}}
 
         # Invoke the agent with the message
         result = await agent.ainvoke(
@@ -104,7 +120,7 @@ def create_bigquery_agent(model_name: Optional[str] = None) -> Callable:
 
 
 if __name__ == "__main__":
-    # setup
+    # python -m SRAgent.agents.bigquery
     from dotenv import load_dotenv
 
     load_dotenv()

--- a/SRAgent/tools/bigquery.py
+++ b/SRAgent/tools/bigquery.py
@@ -11,6 +11,14 @@ from langchain_core.runnables import RunnableConfig
 from SRAgent.tools.utils import to_json, join_accs
 
 
+MISSING_CLIENT_MSG = (
+    "BigQuery requires Google Cloud credentials. "
+    "Enable one of: (1) 'gcloud auth application-default login' and set 'GCP_PROJECT_ID', "
+    "or (2) set 'GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json' and 'GCP_PROJECT_ID'. "
+    "Without credentials, BigQuery tools cannot run."
+)
+
+
 # functions
 @tool
 def get_study_metadata(
@@ -27,8 +35,8 @@ def get_study_metadata(
     - bioproject: BioProject accession (parent of study)
     - experiments: Comma-separated list of associated experiment accessions (SRX)
     """
-    if config is None or config["configurable"]["client"] is None:
-        return "No BigQuery client provided."
+    if config is None or config.get("configurable", {}).get("client") is None:
+        return MISSING_CLIENT_MSG
     query = f"""
     WITH distinct_values AS (
         SELECT DISTINCT
@@ -72,8 +80,8 @@ def get_experiment_metadata(
     - instrument: Sequencing instrument (e.g., HiSeq, NovaSeq)
     - acc: Comma-separated list of associated run accessions (SRR)
     """
-    if config is None or config["configurable"]["client"] is None:
-        return "No BigQuery client provided."
+    if config is None or config.get("configurable", {}).get("client") is None:
+        return MISSING_CLIENT_MSG
     query = f"""
     WITH distinct_values AS (
         SELECT DISTINCT
@@ -124,8 +132,8 @@ def get_run_metadata(
     - avgspotlen: Average spot length (in base pairs)
     - insertsize: Insert size (in base pairs)
     """
-    if config is None or config["configurable"]["client"] is None:
-        return "No BigQuery client provided."
+    if config is None or config.get("configurable", {}).get("client") is None:
+        return MISSING_CLIENT_MSG
     query = f"""
     SELECT 
         m.acc,
@@ -158,8 +166,8 @@ def get_study_experiment_run(
     - experiment_accession: SRA or ENA experiment accession (SRX or ERX)
     - run_accession: SRA or ENA run accession (SRR or ERR)
     """
-    if config is None or config["configurable"]["client"] is None:
-        return "No BigQuery client provided."
+    if config is None or config.get("configurable", {}).get("client") is None:
+        return MISSING_CLIENT_MSG
     # get study accessions
     study_acc = [x for x in accessions if x.startswith("SRP") or x.startswith("PRJNA")]
     exp_acc = [x for x in accessions if x.startswith("SRX") or x.startswith("ERX")]
@@ -196,6 +204,7 @@ def get_study_experiment_run(
 
 
 if __name__ == "__main__":
+    # python -m SRAgent.tools.bigquery
     # setup
     from dotenv import load_dotenv
 

--- a/SRAgent/tools/bigquery.py
+++ b/SRAgent/tools/bigquery.py
@@ -1,6 +1,7 @@
 # import
 ## batteries
 from typing import Annotated, List
+import sys
 
 ## 3rd party
 from google.cloud import bigquery
@@ -17,6 +18,19 @@ MISSING_CLIENT_MSG = (
     "or (2) set 'GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json' and 'GCP_PROJECT_ID'. "
     "Without credentials, BigQuery tools cannot run."
 )
+
+_WARNED_NO_CLIENT = False
+
+def _warn_no_client_once():
+    global _WARNED_NO_CLIENT
+    if not _WARNED_NO_CLIENT:
+        print(
+            "WARNING: BigQuery not used — missing Google Cloud credentials.\n"
+            "- Run: gcloud auth application-default login (and set GCP_PROJECT_ID), or\n"
+            "- Set: GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json and GCP_PROJECT_ID",
+            file=sys.stderr,
+        )
+        _WARNED_NO_CLIENT = True
 
 
 # functions
@@ -36,6 +50,7 @@ def get_study_metadata(
     - experiments: Comma-separated list of associated experiment accessions (SRX)
     """
     if config is None or config.get("configurable", {}).get("client") is None:
+        _warn_no_client_once()
         return MISSING_CLIENT_MSG
     query = f"""
     WITH distinct_values AS (
@@ -81,6 +96,7 @@ def get_experiment_metadata(
     - acc: Comma-separated list of associated run accessions (SRR)
     """
     if config is None or config.get("configurable", {}).get("client") is None:
+        _warn_no_client_once()
         return MISSING_CLIENT_MSG
     query = f"""
     WITH distinct_values AS (
@@ -133,6 +149,7 @@ def get_run_metadata(
     - insertsize: Insert size (in base pairs)
     """
     if config is None or config.get("configurable", {}).get("client") is None:
+        _warn_no_client_once()
         return MISSING_CLIENT_MSG
     query = f"""
     SELECT 
@@ -167,6 +184,7 @@ def get_study_experiment_run(
     - run_accession: SRA or ENA run accession (SRR or ERR)
     """
     if config is None or config.get("configurable", {}).get("client") is None:
+        _warn_no_client_once()
         return MISSING_CLIENT_MSG
     # get study accessions
     study_acc = [x for x in accessions if x.startswith("SRP") or x.startswith("PRJNA")]


### PR DESCRIPTION
- Changed BigQuery client initialization to avoid crashes due to missing application default credentials.
- Added guidance message for users on how to set up Google Cloud credentials when the client is unavailable.
- Updated return messages in tools to provide consistent feedback when the client is not provided.