### PR TITLE
Add Azure OpenAI API support test for SRAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,21 @@ pip install -e ".[dev]"
 * `OPENAI_API_KEY` = API key for using the OpenAI API
   * **required** when using OpenAI models
   * See [Configuring models](#configuring-models) information on setting models
+* `AZURE_OPENAI_API_KEY` = API key for using Azure OpenAI models
+  * **required** when using Azure OpenAI chat models
+* `AZURE_OPENAI_ENDPOINT` = Azure OpenAI resource endpoint
+  * e.g., `https://your-resource.openai.azure.com/`
+* `AZURE_OPENAI_API_VERSION` = Azure OpenAI API version
+  * optional, but recommended
+* `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` = Azure embedding deployment name
+  * optional unless using tissue/disease ontology vector-store tools
 * `ANTHROPIC_API_KEY` = API key for using the Anthropic API
   * **required** when using Claude models
 * `EMAIL` = email for using the Entrez API
   * optional, but **HIGHLY** recommended
 * `NCBI_API_KEY` = API key for using the Entrez API
   * optional, increases rate limits
-* `DYNACONF` = switch between "test", "prod", and "claude" environments
+* `DYNACONF` = switch between "test", "prod", "claude", and "azure" environments
   * optional, default is "prod"
   * this affects the SQL database used and models selected
   * no database is used by default
@@ -520,6 +528,41 @@ export DYNACONF="claude"
 SRAgent entrez "Convert GSE121737 to SRX accessions"
 ```
 
+## Using Azure OpenAI models
+
+SRAgent supports Azure OpenAI deployments through a dedicated `azure` Dynaconf environment.
+
+Required environment variables:
+
+```bash
+export AZURE_OPENAI_API_KEY=your_azure_openai_key
+export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
+export AZURE_OPENAI_API_VERSION="2024-12-01-preview"
+export DYNACONF="azure"
+```
+
+With the default Azure environment, SRAgent expects the chat deployment name to be `gpt-5.2`.
+If your deployment name differs, update the `azure_openai_deployment.default` entry in
+[SRAgent/settings.yml](./SRAgent/settings.yml) or provide a custom settings file via
+`DYNACONF_SETTINGS_PATH`.
+
+Example:
+
+```bash
+export AZURE_OPENAI_API_KEY=your_azure_openai_key
+export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
+export AZURE_OPENAI_API_VERSION="2024-12-01-preview"
+export DYNACONF="azure"
+SRAgent entrez "Convert GSE121737 to SRX accessions"
+```
+
+If you want to use ontology/vector-store tooling (`tissue-ontology` or `disease-ontology`)
+without a regular OpenAI key, you must also create an Azure embedding deployment and set:
+
+```bash
+export AZURE_OPENAI_EMBEDDING_DEPLOYMENT="text-embedding-3-small"
+```
+
 You can also customize the specific Claude model in settings.yml:
 ```yaml
 claude:
@@ -529,6 +572,19 @@ claude:
     default: 0.1
   reasoning_effort:
     default: "medium"  # Set your preferred reasoning effort; use "" to disable
+```
+
+Azure defaults are also configurable in `settings.yml`:
+
+```yaml
+azure:
+  provider: "azure_openai"
+  models:
+    default: "gpt-5.2"
+  azure_openai_deployment:
+    default: "gpt-5.2"
+  azure_openai_api_version:
+    default: "2024-12-01-preview"
 ```
 
 # Setting up the SQL database

--- a/SRAgent/agents/utils.py
+++ b/SRAgent/agents/utils.py
@@ -5,7 +5,7 @@ import asyncio
 from functools import wraps
 from importlib import resources
 from typing import Dict, Any, Optional, Set
-from langchain_openai import ChatOpenAI
+from langchain_openai import ChatOpenAI, AzureChatOpenAI
 from langchain_anthropic import ChatAnthropic
 from dynaconf import Dynaconf
 import openai
@@ -32,6 +32,71 @@ def load_settings() -> Dict[str, Any]:
         settings_files=[s_path], environments=True, env_switcher="DYNACONF"
     )
     return settings
+
+
+def _get_agent_setting(
+    settings: Dict[str, Any], key: str, agent_name: str, default: Any = None
+) -> Any:
+    """
+    Get an agent-specific setting from Dynaconf-style settings.
+
+    The setting may be a scalar value or a mapping keyed by agent name.
+    """
+    try:
+        value = settings[key]
+    except (KeyError, TypeError):
+        return default
+
+    if isinstance(value, dict):
+        if agent_name in value:
+            return value[agent_name]
+        if "default" in value:
+            return value["default"]
+        return default
+
+    try:
+        return value[agent_name]
+    except (KeyError, TypeError, AttributeError):
+        try:
+            return value["default"]
+        except (KeyError, TypeError, AttributeError):
+            return value if value is not None else default
+
+
+def _get_provider(settings: Dict[str, Any], model_name: str, agent_name: str) -> str:
+    """
+    Determine which provider to use for the requested model.
+    """
+    if model_name.startswith("claude"):
+        return "anthropic"
+
+    provider = _get_agent_setting(settings, "provider", agent_name)
+    if provider is None:
+        return "openai"
+
+    provider = str(provider).strip().lower()
+    if provider == "azure":
+        return "azure_openai"
+    if provider == "claude":
+        return "anthropic"
+    return provider
+
+
+def _get_azure_api_version(settings: Dict[str, Any], agent_name: str) -> str:
+    """
+    Resolve the Azure OpenAI API version from settings or environment.
+    """
+    configured_version = _get_agent_setting(
+        settings, "azure_openai_api_version", agent_name
+    )
+    if configured_version:
+        return configured_version
+
+    return (
+        os.getenv("AZURE_OPENAI_API_VERSION")
+        or os.getenv("OPENAI_API_VERSION")
+        or "2024-12-01-preview"
+    )
 
 
 def async_retry_on_flex_timeout(func):
@@ -184,63 +249,38 @@ def set_model(
 
     # Use provided params or get from settings
     if model_name is None:
-        try:
-            model_name = settings["models"][agent_name]
-        except KeyError:
-            # try default
-            try:
-                model_name = settings["models"]["default"]
-            except KeyError:
-                raise ValueError(f"No model name was provided for agent '{agent_name}'")
+        model_name = _get_agent_setting(settings, "models", agent_name)
+        if model_name is None:
+            raise ValueError(f"No model name was provided for agent '{agent_name}'")
 
     if temperature is None:
-        try:
-            temperature = settings["temperature"][agent_name]
-        except KeyError:
-            try:
-                temperature = settings["temperature"]["default"]
-            except KeyError:
-                raise ValueError(
-                    f"No temperature was provided for agent '{agent_name}'"
-                )
+        temperature = _get_agent_setting(settings, "temperature", agent_name)
+        if temperature is None:
+            raise ValueError(f"No temperature was provided for agent '{agent_name}'")
     if reasoning_effort is None:
-        try:
-            reasoning_effort = settings["reasoning_effort"][agent_name]
-        except KeyError:
-            try:
-                reasoning_effort = settings["reasoning_effort"]["default"]
-            except KeyError:
-                if temperature is None:
-                    raise ValueError(
-                        f"No reasoning effort or temperature was provided for agent '{agent_name}'"
-                    )
+        reasoning_effort = _get_agent_setting(
+            settings, "reasoning_effort", agent_name
+        )
+        if reasoning_effort is None and temperature is None:
+            raise ValueError(
+                f"No reasoning effort or temperature was provided for agent '{agent_name}'"
+            )
     if service_tier is None:
-        try:
-            service_tier = settings["service_tier"][agent_name]
-        except (KeyError, TypeError):
-            try:
-                service_tier = settings["service_tier"]["default"]
-            except (KeyError, TypeError):
-                try:
-                    service_tier = settings["service_tier"]
-                except (KeyError, TypeError):
-                    service_tier = "default"  # fallback to default service tier
+        service_tier = _get_agent_setting(
+            settings, "service_tier", agent_name, default="default"
+        )
 
     # Get timeout from settings (optional)
-    timeout = None
-    try:
-        timeout = settings["flex_timeout"][agent_name]
-    except (KeyError, TypeError):
-        try:
-            timeout = settings["flex_timeout"]["default"]
-        except (KeyError, TypeError):
-            try:
-                timeout = settings["flex_timeout"]
-            except (KeyError, TypeError):
-                timeout = 180.0  # Default value
+    timeout = _get_agent_setting(settings, "flex_timeout", agent_name, default=180.0)
+
+    provider = _get_provider(settings, model_name=model_name, agent_name=agent_name)
 
     # Validate service_tier for OpenAI models
-    if service_tier == "flex" and not re.search(r"^(o[0-9]|^gpt-5)", model_name):
+    if (
+        provider == "openai"
+        and service_tier == "flex"
+        and not re.search(r"^(o[0-9]|^gpt-5)", model_name)
+    ):
         raise ValueError(
             f"Service tier 'flex' only works with o3 and o4-mini, & gpt-5* models, not {model_name} (agent: {agent_name})"
         )
@@ -256,7 +296,7 @@ def set_model(
     }
 
     # Check model provider and initialize appropriate model
-    if model_name.startswith("claude"):  # e.g.,  "claude-3-7-sonnet-20250219"
+    if provider == "anthropic":  # e.g.,  "claude-3-7-sonnet-20250219"
         if agent_name in STRUCTURED_OUTPUT_AGENTS:
             think_tokens = 0
         elif reasoning_effort == "low":
@@ -287,6 +327,57 @@ def set_model(
             thinking=thinking,
             max_tokens=max_tokens,
         )
+    elif provider == "azure_openai":
+        if service_tier == "flex":
+            raise ValueError(
+                "Service tier 'flex' is not supported for Azure OpenAI deployments"
+            )
+
+        azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+        azure_api_key = os.getenv("AZURE_OPENAI_API_KEY")
+        if not azure_endpoint:
+            raise ValueError(
+                "AZURE_OPENAI_ENDPOINT must be set when provider is azure_openai"
+            )
+        if not azure_api_key:
+            raise ValueError(
+                "AZURE_OPENAI_API_KEY must be set when provider is azure_openai"
+            )
+
+        azure_model_name = _get_agent_setting(
+            settings, "azure_openai_model", agent_name, default=model_name
+        )
+        azure_deployment = _get_agent_setting(
+            settings, "azure_openai_deployment", agent_name, default=model_name
+        )
+        azure_model_version = _get_agent_setting(
+            settings,
+            "azure_openai_model_version",
+            agent_name,
+            default=os.getenv("AZURE_OPENAI_MODEL_VERSION"),
+        )
+        azure_api_version = _get_azure_api_version(settings, agent_name)
+
+        azure_kwargs = {
+            "azure_deployment": azure_deployment,
+            "api_version": azure_api_version,
+            "azure_endpoint": azure_endpoint,
+            "api_key": azure_api_key,
+            "model": azure_model_name,
+        }
+        if azure_model_version:
+            azure_kwargs["model_version"] = azure_model_version
+        if max_tokens is not None:
+            azure_kwargs["max_tokens"] = max_tokens
+
+        if azure_model_name.startswith("gpt-4"):
+            azure_kwargs["temperature"] = temperature
+        elif re.search(r"(^o[0-9]|^gpt-5)", azure_model_name):
+            azure_kwargs["reasoning_effort"] = reasoning_effort
+        else:
+            raise ValueError(f"Model {azure_model_name} not supported")
+
+        model = AzureChatOpenAI(**azure_kwargs)
     elif model_name.startswith("gpt-4"):
         # GPT-4o models use temperature but not reasoning_effort
         # Use FlexTierChatOpenAI for automatic fallback support

--- a/SRAgent/cli/__main__.py
+++ b/SRAgent/cli/__main__.py
@@ -32,9 +32,13 @@ def arg_parse(args=None) -> dict:
     interacting with the SRA and Entrez.
     """
     # check for OP
-    if os.getenv("OPENAI_API_KEY") is None and os.getenv("ANTHROPIC_API_KEY") is None:
+    if (
+        os.getenv("OPENAI_API_KEY") is None
+        and os.getenv("ANTHROPIC_API_KEY") is None
+        and os.getenv("AZURE_OPENAI_API_KEY") is None
+    ):
         raise ValueError(
-            "You must set either the OPENAI_API_KEY or ANTHROPIC_API_KEY environment variable"
+            "You must set OPENAI_API_KEY, ANTHROPIC_API_KEY, or AZURE_OPENAI_API_KEY"
         )
 
     # main parser

--- a/SRAgent/settings.yml
+++ b/SRAgent/settings.yml
@@ -3,11 +3,13 @@ default:
   db_port: 5432
   db_user: "postgres"
   db_timeout: 30
+  provider: "openai"
   service_tier: "standard"
   flex_timeout: 180
 
 test:
   db_name: "sragent-test"
+  provider: "openai"
   models:
     default: "gpt-5-mini"
     esearch: "gpt-5-mini"
@@ -95,6 +97,7 @@ test:
     
 prod:
   db_name: "sragent-prod"
+  provider: "openai"
   models:
     default: "gpt-5-mini"
     esearch: "gpt-5-mini"
@@ -182,6 +185,7 @@ prod:
   
 claude:
   db_name: "sragent-test"
+  provider: "anthropic"
   models:
     default: "claude-sonnet-4-5"
   temperature:
@@ -207,3 +211,21 @@ claude:
     step_summary: ""
   service_tier:
     default: "default"
+
+azure:
+  db_name: "sragent-test"
+  provider: "azure_openai"
+  models:
+    default: "gpt-5.2"
+  temperature:
+    default: 0.1
+  reasoning_effort:
+    default: "low"
+  service_tier:
+    default: "default"
+  azure_openai_deployment:
+    default: "gpt-5.2"
+  azure_openai_model:
+    default: "gpt-5.2"
+  azure_openai_api_version:
+    default: "2024-12-01-preview"

--- a/SRAgent/tools/vector_db.py
+++ b/SRAgent/tools/vector_db.py
@@ -5,7 +5,7 @@ import sys
 
 ## 3rd party
 import chromadb
-from langchain_openai import OpenAIEmbeddings
+from langchain_openai import OpenAIEmbeddings, AzureOpenAIEmbeddings
 from langchain_chroma import Chroma
 
 
@@ -52,8 +52,48 @@ def load_vector_store(chroma_path: str, collection_name: str = "uberon") -> Chro
     if not os.path.exists(chroma_path):
         raise FileNotFoundError(f"Chroma DB directory not found: {chroma_path}")
 
-    # Initialize embeddings
-    embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
+    # Initialize embeddings. Azure OpenAI requires a dedicated embedding deployment.
+    embedding_provider = os.getenv("SRAGENT_EMBEDDING_PROVIDER")
+    embedding_model = os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
+
+    if embedding_provider is None and os.getenv("AZURE_OPENAI_EMBEDDING_DEPLOYMENT"):
+        embedding_provider = "azure_openai"
+    elif embedding_provider is None:
+        embedding_provider = "openai"
+
+    embedding_provider = embedding_provider.lower()
+
+    if embedding_provider == "azure_openai":
+        azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+        azure_api_key = os.getenv("AZURE_OPENAI_API_KEY")
+        azure_deployment = os.getenv("AZURE_OPENAI_EMBEDDING_DEPLOYMENT")
+        azure_api_version = (
+            os.getenv("AZURE_OPENAI_API_VERSION")
+            or os.getenv("OPENAI_API_VERSION")
+            or "2024-12-01-preview"
+        )
+
+        if not azure_endpoint or not azure_api_key or not azure_deployment:
+            raise ValueError(
+                "Azure OpenAI embeddings require AZURE_OPENAI_ENDPOINT, "
+                "AZURE_OPENAI_API_KEY, and AZURE_OPENAI_EMBEDDING_DEPLOYMENT"
+            )
+
+        embeddings = AzureOpenAIEmbeddings(
+            model=os.getenv("AZURE_OPENAI_EMBEDDING_MODEL", embedding_model),
+            azure_deployment=azure_deployment,
+            azure_endpoint=azure_endpoint,
+            api_key=azure_api_key,
+            api_version=azure_api_version,
+        )
+    else:
+        if os.getenv("OPENAI_API_KEY") is None and os.getenv("AZURE_OPENAI_API_KEY"):
+            raise ValueError(
+                "OpenAI embeddings were selected, but OPENAI_API_KEY is not set. "
+                "Set OPENAI_API_KEY or configure Azure embeddings with "
+                "AZURE_OPENAI_EMBEDDING_DEPLOYMENT."
+            )
+        embeddings = OpenAIEmbeddings(model=embedding_model)
 
     # Load the persistent Chroma client
     persistent_client = chromadb.PersistentClient(path=chroma_path)

--- a/tests/agents/test_utils.py
+++ b/tests/agents/test_utils.py
@@ -237,3 +237,55 @@ class TestSetModel:
                 thinking={"type": "disabled"},
                 max_tokens=1024,
             )
+
+    @patch("SRAgent.agents.utils.load_settings")
+    @patch.dict(
+        "os.environ",
+        {
+            "AZURE_OPENAI_ENDPOINT": "https://example-resource.openai.azure.com/",
+            "AZURE_OPENAI_API_KEY": "test-key",
+        },
+        clear=False,
+    )
+    def test_set_model_with_azure_openai(self, mock_load_settings):
+        """Test set_model with Azure OpenAI provider."""
+        mock_settings = {
+            "provider": {"default": "azure_openai"},
+            "models": {"default": "gpt-5.2"},
+            "temperature": {"default": 0.1},
+            "reasoning_effort": {"default": "medium"},
+            "service_tier": {"default": "default"},
+            "azure_openai_deployment": {"default": "gpt-5.2"},
+            "azure_openai_model": {"default": "gpt-5.2"},
+            "azure_openai_api_version": {"default": "2024-12-01-preview"},
+        }
+        mock_load_settings.return_value = mock_settings
+
+        with patch("SRAgent.agents.utils.AzureChatOpenAI") as mock_chat:
+            model = set_model()
+            mock_chat.assert_called_once_with(
+                azure_deployment="gpt-5.2",
+                api_version="2024-12-01-preview",
+                azure_endpoint="https://example-resource.openai.azure.com/",
+                api_key="test-key",
+                model="gpt-5.2",
+                reasoning_effort="medium",
+            )
+
+    @patch("SRAgent.agents.utils.load_settings")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_set_model_with_azure_openai_missing_endpoint(self, mock_load_settings):
+        """Test Azure OpenAI raises a clear error when endpoint is missing."""
+        mock_settings = {
+            "provider": {"default": "azure_openai"},
+            "models": {"default": "gpt-5.2"},
+            "temperature": {"default": 0.1},
+            "reasoning_effort": {"default": "medium"},
+        }
+        mock_load_settings.return_value = mock_settings
+
+        with pytest.raises(
+            ValueError,
+            match="AZURE_OPENAI_ENDPOINT must be set when provider is azure_openai",
+        ):
+            set_model()

--- a/tests/tools/test_tissue_ontology.py
+++ b/tests/tools/test_tissue_ontology.py
@@ -90,7 +90,8 @@ def mock_requests_get():
 def mock_chroma():
     with patch('SRAgent.tools.vector_db.chromadb.PersistentClient') as mock_client, \
          patch('SRAgent.tools.vector_db.Chroma') as mock_chroma, \
-         patch('SRAgent.tools.vector_db.OpenAIEmbeddings') as mock_embeddings:
+         patch('SRAgent.tools.vector_db.OpenAIEmbeddings') as mock_embeddings, \
+         patch('SRAgent.tools.vector_db.AzureOpenAIEmbeddings') as mock_azure_embeddings:
         
         # Configure mock chroma collection
         mock_collection = MagicMock()
@@ -107,6 +108,37 @@ def mock_chroma():
         mock_chroma.return_value = mock_vector_store
         
         yield mock_chroma
+
+
+@patch('os.path.exists', return_value=True)
+def test_load_vector_store_with_azure_embeddings(mock_exists):
+    """Test load_vector_store with Azure OpenAI embeddings."""
+    with patch.dict(
+        os.environ,
+        {
+            "AZURE_OPENAI_ENDPOINT": "https://example-resource.openai.azure.com/",
+            "AZURE_OPENAI_API_KEY": "test-key",
+            "AZURE_OPENAI_EMBEDDING_DEPLOYMENT": "text-embedding-3-small",
+        },
+        clear=False,
+    ):
+        with patch('SRAgent.tools.vector_db.chromadb.PersistentClient') as mock_client, \
+             patch('SRAgent.tools.vector_db.Chroma') as mock_chroma, \
+             patch('SRAgent.tools.vector_db.AzureOpenAIEmbeddings') as mock_embeddings:
+
+            mock_collection = MagicMock()
+            mock_collection.count.return_value = 10
+            mock_client.return_value.get_collection.return_value = mock_collection
+
+            load_vector_store('/tmp/chroma', collection_name='uberon')
+
+            mock_embeddings.assert_called_once_with(
+                model='text-embedding-3-small',
+                azure_deployment='text-embedding-3-small',
+                azure_endpoint='https://example-resource.openai.azure.com/',
+                api_key='test-key',
+                api_version='2024-12-01-preview',
+            )
 
 
 # Mock for tarfile


### PR DESCRIPTION
## Summary

This PR adds Azure OpenAI support to SRAgent.

It introduces an `azure` Dynaconf environment, routes model setup through `AzureChatOpenAI` when configured, adds Azure embedding support for vector-store workflows, and updates the CLI/tests/docs so the new provider can be exercised without changing the existing OpenAI or Claude paths.

## What changed

- added Azure provider support in `set_model()`
- added an `azure` environment in `SRAgent/settings.yml`
- allowed `AZURE_OPENAI_API_KEY` in CLI startup validation
- added Azure embedding support in `SRAgent/tools/vector_db.py`
- documented Azure setup in `README.md`
- added tests for Azure chat and embedding config

## How to test

```bash
pip install -e ".[dev]"

export DYNACONF="azure"
export AZURE_OPENAI_ENDPOINT="https://<your-resource>.openai.azure.com/"
export AZURE_OPENAI_API_KEY="<your-key>"
export AZURE_OPENAI_API_VERSION="2024-12-01-preview"

SRAgent --no-progress --no-summaries entrez "Convert GSE121737 to SRX accessions"
```

Optional embedding test:

```bash
export AZURE_OPENAI_EMBEDDING_DEPLOYMENT="text-embedding-3-small"
export AZURE_OPENAI_EMBEDDING_MODEL="text-embedding-3-small"

SRAgent --no-progress --no-summaries tissue-ontology "Categorize the following tissue: brain"
```

Notes
- Azure does not use the existing flex service-tier path.
- Embedding workflows require a separate Azure embedding deployment.
- If your Azure resource requires a different API version, update AZURE_OPENAI_API_VERSION and/or the azure config in SRAgent/settings.yml.